### PR TITLE
Corrected some typos and added int specialization for TaskPrimitive

### DIFF
--- a/hms-sdk-unity/HuaweiMobileServices/Base/TaskPrimitive.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Base/TaskPrimitive.cs
@@ -18,4 +18,11 @@ namespace HuaweiMobileServices.Base
             return this;
         }
     }
+
+    [UnityEngine.Scripting.Preserve]
+    internal class TaskPrimitiveInt : TaskPrimitive<int>
+    {
+        [UnityEngine.Scripting.Preserve]
+        public TaskPrimitiveInt(AndroidJavaObject javaObject) : base(javaObject) { }
+    }
 }

--- a/hms-sdk-unity/HuaweiMobileServices/Game/RankingScores.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Game/RankingScores.cs
@@ -15,7 +15,7 @@ namespace HuaweiMobileServices.Game
 
         public Ranking Ranking => CallAsWrapper<Ranking>("getRanking");
 
-        public IList<RankingScore> RankingScore => CallAsWrapperList<RankingScore>("getRankingScore");
+        public IList<RankingScore> RankingScore => CallAsWrapperList<RankingScore>("getRankingScores");
 
     }
 }

--- a/hms-sdk-unity/HuaweiMobileServices/Game/RankingsClientWrapper.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Game/RankingsClientWrapper.cs
@@ -11,7 +11,7 @@ namespace HuaweiMobileServices.Game
     internal class RankingsClientWrapper : JavaObjectWrapper, IRankingsClient
     {
 
-        private static readonly AndroidJavaClass sJavaClass = new AndroidJavaClass("org.m0skit0.android.hms.unity.GenericBridge");
+        private static readonly AndroidJavaClass sJavaClass = new AndroidJavaClass("com.huawei.hms.jos.games.RankingsClient");
 
         [UnityEngine.Scripting.Preserve]
         public RankingsClientWrapper(AndroidJavaObject javaObject) : base(javaObject) { }

--- a/hms-sdk-unity/HuaweiMobileServices/Game/RankingsClientWrapper.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Game/RankingsClientWrapper.cs
@@ -11,7 +11,7 @@ namespace HuaweiMobileServices.Game
     internal class RankingsClientWrapper : JavaObjectWrapper, IRankingsClient
     {
 
-        private static readonly AndroidJavaClass sJavaClass = new AndroidJavaClass("com.huawei.hms.jos.games.RankingsClient");
+        private static readonly AndroidJavaClass sJavaClass = new AndroidJavaClass("org.m0skit0.android.hms.unity.GenericBridge");
 
         [UnityEngine.Scripting.Preserve]
         public RankingsClientWrapper(AndroidJavaObject javaObject) : base(javaObject) { }


### PR DESCRIPTION
About the last, it was necessary because at least in unity 2019.2 IL2CPP didn't produce AOT code for TaskPrimitive<int> without it